### PR TITLE
fix(dart-map): prevent color-by-metric column from bleeding into hover tooltip

### DIFF
--- a/superset-frontend/plugins/dart-map-chart/src/layers/DartLayer/DartLayer.tsx
+++ b/superset-frontend/plugins/dart-map-chart/src/layers/DartLayer/DartLayer.tsx
@@ -49,7 +49,6 @@ import {
   getCategories,
   MetricLegend,
   normalizeCategoryColorMapping,
-  rgbaArrayToHex,
 } from '../../utils/colors';
 import sandboxedEval from '../../utils/sandbox';
 import { commonLayerProps } from '../common';
@@ -177,12 +176,7 @@ const recurseGeoJson = (
   return localFeatures;
 };
 
-function setTooltipContent(
-  o: JsonObject,
-  hoverColumnNames?: string[],
-  metric?: ColorByValueConfig,
-  metricName?: string,
-) {
+function setTooltipContent(o: JsonObject, hoverColumnNames?: string[]) {
   const props = o.object?.properties;
   if (!props) return null;
 
@@ -193,26 +187,9 @@ function setTooltipContent(
 
   const content: JSX.Element[] = [];
 
-  // Add metric first if available
-  if (metric) {
-    // Render metric first (in order)
-    if (props[`color_${metric.valueColumn}`] !== undefined) {
-      const colorArr = props[`color_${metric.valueColumn}`];
-      const hexColor = rgbaArrayToHex(colorArr);
-      content.push(
-        <TooltipRow
-          key={`metric-${metric.valueColumn}`}
-          label={`${metric.valueColumn}: `}
-          value={`${props[metric.valueColumn]}`}
-          color={hexColor}
-        />,
-      );
-    }
-  }
-
-  // Add all other properties except ones in propertyKeys
+  // Show only the columns the user selected in hover data
   Object.keys(props)
-    .filter(key => hoverColumnNames.includes(key) && metricName !== key)
+    .filter(key => hoverColumnNames.includes(key))
     .forEach((prop, index) => {
       content.push(
         <TooltipRow
@@ -362,12 +339,7 @@ export function getLayer(
 
   // Create tooltip content generator with hover column filtering
   const tooltipContentGenerator = (o: JsonObject) =>
-    setTooltipContent(
-      o,
-      hoverColumnNames,
-      metric,
-      payload.data.metricLabels?.[0],
-    );
+    setTooltipContent(o, hoverColumnNames);
 
   // Shared props for all layer types
   const baseLayerProps = {


### PR DESCRIPTION
## Summary

- Removed automatic addition of metric column to hover tooltip
- Tooltip now only shows columns explicitly selected in "Hover Data Columns" control
- Cleaned up unused parameters and imports in `setTooltipContent` function

## Focus Score

**10/10** - This PR makes a single, focused change: fixing the hover tooltip to respect user's column selection instead of automatically injecting the color-by-metric column.

## Detailed Summary of Each File Changed

### `superset-frontend/plugins/dart-map-chart/src/layers/DartLayer/DartLayer.tsx`
- **Removed** the special metric handling block in `setTooltipContent()` that was automatically adding the color-by-value metric column to the tooltip with a color swatch
- **Simplified** the `setTooltipContent()` function signature by removing unused `metric` and `metricName` parameters
- **Removed** the `rgbaArrayToHex` import since it was only used by the removed metric handling code
- **Updated** the tooltip content generator call to pass only the required arguments
- The tooltip now simply shows whatever columns the user selected in "Hover Data Columns" - nothing more, nothing less

## Test Plan

1. Open a DART Layer chart with "Color by Metric" configured (e.g., color by `incident_size`)
2. In "Hover Data Columns", select a column that is NOT the metric column
3. Hover over a feature on the map
4. **Verify** the tooltip shows ONLY the selected hover columns, NOT the metric column
5. Add the metric column to "Hover Data Columns"
6. **Verify** the metric now appears in the tooltip (as regular text, no color swatch)