### PR TITLE
fix(dart-map): restore popup functionality for initially hidden layers

### DIFF
--- a/superset-frontend/plugins/dart-map-chart/src/DartMap/Multi.tsx
+++ b/superset-frontend/plugins/dart-map-chart/src/DartMap/Multi.tsx
@@ -112,6 +112,7 @@ type SubsliceLayerEntry = {
     categories: Record<string, CategoryState>;
     visualConfig: any;
     hoverColumnNames: string[];
+    featureInfoColumnNames: string[];
   };
   zoomSliderOptions: { minZoom: number; maxZoom: number };
   initiallyHidden: boolean; // Whether this layer starts hidden
@@ -465,6 +466,8 @@ const DeckMulti = (props: DeckMultiProps) => {
                     categories: transformedProps.categories || {},
                     visualConfig: transformedProps.visualConfig,
                     hoverColumnNames: transformedProps.hoverColumnNames,
+                    featureInfoColumnNames:
+                      transformedProps.featureInfoColumnNames || [],
                   },
                   zoomSliderOptions: newLayerStateOptions,
                   initiallyHidden: sliceInitiallyHidden,
@@ -662,6 +665,11 @@ const DeckMulti = (props: DeckMultiProps) => {
           updatedCategories,
           entry.transformedProps.visualConfig,
           entry.transformedProps.hoverColumnNames,
+          (info: any) =>
+            handleFeatureClick(
+              info,
+              entry.transformedProps.featureInfoColumnNames,
+            ),
         );
 
         if (!newLayer) {
@@ -702,7 +710,7 @@ const DeckMulti = (props: DeckMultiProps) => {
 
       return anyChanged ? updatedLayers : currentLayers;
     });
-  }, [categoryVisibility, props.onAddFilter, setTooltip]);
+  }, [categoryVisibility, props.onAddFilter, setTooltip, handleFeatureClick]);
 
   // Sync layer visibility with category visibility
   // If all categories are off, hide the layer; if any category is on, show the layer


### PR DESCRIPTION
## Summary

- Fixed a bug where click popups would not work on layers that were initially hidden and then toggled visible
- The issue was that when rebuilding layers due to category visibility changes, the `onFeatureClick` handler was not being passed to `getDartMapLayer`

## Focus Score

**10/10** - This PR is highly focused. It addresses a single bug in one file with minimal, targeted changes. All modifications are directly related to restoring the popup click functionality.

## Detailed Summary of Each File Changed

### `superset-frontend/plugins/dart-map-chart/src/DartMap/Multi.tsx`

1. **Line 115** - Added `featureInfoColumnNames: string[]` to the `transformedProps` type definition to store column names needed for rebuilding layers with proper popup functionality

2. **Lines 468-469** - Store `featureInfoColumnNames` from `transformedProps` when creating layer entries (with `|| []` fallback for safety)

3. **Lines 665-670** - Pass the `handleFeatureClick` callback to `getDartMapLayer` when rebuilding layers in the `categoryVisibility` effect. This was the core fix - previously the click handler was omitted during layer rebuilds

4. **Line 710** - Added `handleFeatureClick` to the useEffect dependency array to satisfy React's exhaustive deps rule

## Test Plan

1. Create a multi-chart with at least one layer configured as "initially hidden"
2. Load the chart - verify the hidden layer is not visible
3. Toggle the hidden layer to visible using the legend controls
4. Click on a feature in that layer
5. **Expected result**: The popup should appear with feature properties
6. **Previous behavior**: The popup would not appear

Additionally, verify that:
- Layers that were NOT initially hidden still have working popups
- Toggling layers off and back on preserves popup functionality
- Category toggles on categorical layers still work correctly with popups