### PR TITLE
fix(dart-map): reposition UI elements for consistent layout

### DIFF
--- a/superset-frontend/plugins/dart-map-chart/src/components/Legend.tsx
+++ b/superset-frontend/plugins/dart-map-chart/src/components/Legend.tsx
@@ -27,11 +27,8 @@ import { rgbaArrayToCssString } from '../utils/colorsFallback';
 import { Swatch } from '../utils/legendSwatch';
 import { formatLegendNumber } from '../utils/formatNumber';
 
-// MapControls: top 12px + height 32px + padding 12px = 56px from top
-const MAP_CONTROLS_OFFSET = 56;
-
-const StyledLegend = styled.div<{ $isTopLeft?: boolean }>`
-  ${({ theme, $isTopLeft }) => `
+const StyledLegend = styled.div`
+  ${({ theme }) => `
     font-size: ${theme.fontSize}px;
     position: absolute;
     background: ${theme.colorBgElevated};
@@ -43,9 +40,7 @@ const StyledLegend = styled.div<{ $isTopLeft?: boolean }>`
     max-width: 220px;
     border-radius: 6px;
     z-index: 10;
-
-    /* For top-left position (same corner as MapControls), limit max-height to avoid overlap */
-    max-height: ${$isTopLeft ? `calc(100% - ${MAP_CONTROLS_OFFSET + 24}px)` : 'calc(100% - 24px)'};
+    max-height: calc(100% - 24px);
 
     & ul {
       list-style: none;
@@ -222,23 +217,14 @@ const Legend = ({
   const vertical = isTop ? 'top' : 'bottom';
   const horizontal = isLeft ? 'left' : 'right';
 
-  // Check if legend is in top-left corner (same as MapControls)
-  const isTopLeft = isTop && isLeft;
-
   const style: React.CSSProperties = {
     position: 'absolute',
     [horizontal]: '10px',
+    [vertical]: '0px',
   };
 
-  // For top-left, offset below MapControls; otherwise use standard positioning
-  if (isTopLeft) {
-    style.top = `${MAP_CONTROLS_OFFSET}px`;
-  } else {
-    style[vertical] = '0px';
-  }
-
   return (
-    <StyledLegend $isTopLeft={isTopLeft} style={style}>
+    <StyledLegend style={style}>
       {metricLegendContent}
       <ul>{categories}</ul>
     </StyledLegend>

--- a/superset-frontend/plugins/dart-map-chart/src/layers/DartLayer/DartLayer.tsx
+++ b/superset-frontend/plugins/dart-map-chart/src/layers/DartLayer/DartLayer.tsx
@@ -1125,7 +1125,7 @@ const DeckGLGeoJson = (props: DeckGLGeoJsonProps) => {
         categories={categories}
         metricLegend={metricLegend}
         format={props.formData.legend_format}
-        position={props.formData.legend_position}
+        position="tl"
         showSingleCategory={showSingleCategory}
         toggleCategory={toggleCategory}
         icon={propVisualConfig?.pointType}
@@ -1137,6 +1137,7 @@ const DeckGLGeoJson = (props: DeckGLGeoJsonProps) => {
         onResetView={handleResetView}
         onRulerToggle={handleRulerToggle}
         isRulerActive={measureState.isActive}
+        position="top-right"
       />
       <MeasureOverlay
         measureState={measureState}
@@ -1150,7 +1151,7 @@ const DeckGLGeoJson = (props: DeckGLGeoJsonProps) => {
           feature={clickedFeature}
           onClose={handleClosePopup}
           featureInfoColumnNames={featureInfoColumnNames}
-          position="left"
+          position="right"
         />
       )}
       {limitReached && (


### PR DESCRIPTION
## Summary

- Standardized DartLayer UI layout to match Multi chart positioning
- Legend now hardcoded to top-left (previously configurable, often defaulted to top-right)
- MapControls moved from top-left to top-right
- Click popup moved from left side to right side (under MapControls)
- Removed unnecessary `isTopLeft` offset logic from Legend component

## Focus Score

**9/10** - This PR is highly focused on repositioning UI elements within the DartLayer chart. All changes are related to the single goal of standardizing the layout. The only reason it's not a 10 is that it touches two files, but both changes are directly related.

## Detailed Summary of Each File Changed

### `superset-frontend/plugins/dart-map-chart/src/layers/DartLayer/DartLayer.tsx`

1. **Line 1128** - Changed Legend `position` from `props.formData.legend_position` (configurable) to hardcoded `"tl"` (top-left)
2. **Line 1140** - Added `position="top-right"` to MapControls (was defaulting to top-left)
3. **Line 1153** - Changed ClickPopupBox `position` from `"left"` to `"right"`

### `superset-frontend/plugins/dart-map-chart/src/components/Legend.tsx`

1. Removed `MAP_CONTROLS_OFFSET` constant (no longer needed)
2. Removed `$isTopLeft` prop from `StyledLegend` styled component
3. Simplified `max-height` calculation (no longer needs conditional based on MapControls position)
4. Removed `isTopLeft` variable and the conditional offset logic that pushed the legend down 56px when in the top-left corner
5. Simplified style object to always use standard positioning

## Test Plan

1. Open a standalone DartLayer chart (not Multi)
2. Verify the layout matches the expected positioning:
   - **Legend**: Top-left corner
   - **MapControls**: Top-right corner (zoom buttons, ruler)
   - **Click Popup**: Right side, below MapControls (click on a feature to test)
3. Compare positioning with a Multi chart to ensure consistency
4. Test that legend expands/collapses correctly in its new position
5. Test that click popup appears correctly when clicking features

🤖 Generated with [Claude Code](https://claude.com/claude-code)