### PR TITLE
fix(dart-map): collapse inline arrays in JSON editor for readability

### DIFF
--- a/superset-frontend/plugins/dart-map-chart/src/components/JsonEditorControl.tsx
+++ b/superset-frontend/plugins/dart-map-chart/src/components/JsonEditorControl.tsx
@@ -11,6 +11,7 @@ import {
 } from '@ant-design/icons';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-json';
+import { prettyStringify } from '../utils/safeStringify';
 
 const { Text } = Typography;
 
@@ -217,6 +218,20 @@ type JsonEditorControlProps = {
   defaultValue: string;
 };
 
+/**
+ * Normalize JSON string: parse then re-stringify with prettyStringify
+ * so small arrays (like RGBA values) stay on one line.
+ * Returns the original string if parsing fails (e.g. invalid JSON while editing).
+ */
+function normalizeJson(raw: string): string {
+  if (!raw || !raw.trim().startsWith('{')) return raw;
+  try {
+    return prettyStringify(JSON.parse(raw));
+  } catch {
+    return raw;
+  }
+}
+
 export default function JsonEditorControl({
   label,
   value,
@@ -224,7 +239,7 @@ export default function JsonEditorControl({
   defaultValue,
 }: JsonEditorControlProps) {
   const [localValue, setLocalValue] = useState<string>(() => {
-    if (value != null && value !== '') return value;
+    if (value != null && value !== '') return normalizeJson(value);
     if (defaultValue != null) return defaultValue;
     return '';
   });
@@ -232,13 +247,21 @@ export default function JsonEditorControl({
 
   useEffect(() => {
     if (value != null && value !== '' && value !== localValue) {
-      setLocalValue(value);
+      setLocalValue(normalizeJson(value));
     }
   }, [value]);
 
   const handleChange = (newCode: string) => {
     setLocalValue(newCode);
     onChange?.(newCode);
+  };
+
+  const handleBlur = () => {
+    const normalized = normalizeJson(localValue);
+    if (normalized !== localValue) {
+      setLocalValue(normalized);
+      onChange?.(normalized);
+    }
   };
 
   const handleCopy = async () => {
@@ -303,7 +326,7 @@ export default function JsonEditorControl({
           </Popover>
         </LabelRow>
       )}
-      <EditorWrapper>
+      <EditorWrapper onBlur={handleBlur}>
         <Editor
           value={localValue}
           onValueChange={handleChange}

--- a/superset-frontend/plugins/dart-map-chart/src/utils/safeStringify.ts
+++ b/superset-frontend/plugins/dart-map-chart/src/utils/safeStringify.ts
@@ -27,7 +27,6 @@ import { JsonObject } from '@superset-ui/core';
  * @param object any JSON object to be stringified
  */
 
-// eslint-disable-next-line import/prefer-default-export
 export function safeStringify(object: JsonObject) {
   const cache = new Set();
 
@@ -49,4 +48,15 @@ export function safeStringify(object: JsonObject) {
 
     return value;
   });
+}
+
+/**
+ * JSON.stringify with 2-space indent, but collapses small primitive arrays
+ * (like RGBA values) onto a single line.
+ */
+export function prettyStringify(obj: unknown): string {
+  return JSON.stringify(obj, null, 2).replace(
+    /\[\s*\n\s*((?:-?\d+(?:\.\d+)?|null|true|false|"[^"]*")(?:,\s*\n\s*(?:-?\d+(?:\.\d+)?|null|true|false|"[^"]*"))*)\s*\n\s*\]/g,
+    (_, inner: string) => `[${inner.replace(/\s*\n\s*/g, ' ')}]`,
+  );
 }


### PR DESCRIPTION
## Summary
- Added `prettyStringify` utility that collapses small primitive arrays (like RGBA `[40, 147, 179, 255]`) onto single lines instead of expanding across 4+ lines
- Added `normalizeJson` in `JsonEditorControl` to auto-format JSON on load, value sync, and editor blur



## Test plan
- [ ] Open a dart-map chart with existing geojsonConfig containing RGBA arrays
- [ ] Verify arrays like `[40, 147, 179, 255]` display on a single line in the JSON editor
- [ ] Edit the JSON and click away (blur) — verify formatting is reapplied
- [ ] Verify invalid JSON while editing doesn't cause errors (graceful fallback)
- [ ] Save and reload — confirm formatting persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)