### PR TITLE
Fix: Make Layer Toggling More Responsive For Users

### DIFF
--- a/superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx
+++ b/superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx
@@ -235,6 +235,9 @@ export const MultiLegend: React.FC<MultiLegendProps> = ({
 
   const [isLegendOpen, setIsLegendOpen] = useState(false);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [optimisticVisibility, setOptimisticVisibility] = useState<
+    Record<string, boolean>
+  >({});
 
   const toggle = (id: string) => {
     const group = legendsBySlice[id];
@@ -283,7 +286,10 @@ export const MultiLegend: React.FC<MultiLegendProps> = ({
             const isOpen = expanded[id] ?? !group.initialCollapsed;
             const { fill, stroke } = getDefaultColors(group);
 
-            const isVisible = layerVisibility[id] !== false; // default to visible
+            const isVisible =
+              id in optimisticVisibility
+                ? optimisticVisibility[id]
+                : layerVisibility[id] !== false; // default to visible
 
             // Calculate indeterminate state for categorical layers
             const categories = group.categories || [];
@@ -305,6 +311,10 @@ export const MultiLegend: React.FC<MultiLegendProps> = ({
                       indeterminate={isIndeterminate}
                       onChange={e => {
                         e.stopPropagation();
+                        setOptimisticVisibility(prev => ({
+                          ...prev,
+                          [id]: !isVisible,
+                        }));
                         onToggleLayerVisibility?.(id);
                       }}
                     />


### PR DESCRIPTION
## Summary

- Added optimistic UI state for layer toggle visibility in the MultiLegend component to eliminate the perceived delay when toggling layer visibility

## Focus Score

**10/10** — This MR changes a single file to address a single UX issue: the delay when toggling layer visibility in the MultiLegend. All changes are tightly scoped to introducing optimistic state management for the checkbox toggle.

## Detailed Summary of Each File Changed

### `superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx`
- Added a new `optimisticVisibility` state (`Record<string, boolean>`) to track the user's intended visibility before the parent state updates
- Updated the `isVisible` derivation to prefer the optimistic value when present, falling back to the existing `layerVisibility` prop
- Updated the checkbox `onChange` handler to immediately set the optimistic visibility before invoking the `onToggleLayerVisibility` callback, ensuring the UI responds instantly

## Test Plan

- [ ] Open a dashboard with a multi-layer GeoSet map chart
- [ ] Toggle individual layer visibility checkboxes in the MultiLegend panel
- [ ] Verify the checkbox state updates immediately on click with no visible delay
- [ ] Verify the layer on the map still toggles correctly after the optimistic update
- [ ] Verify toggling rapidly back and forth does not cause stale or inconsistent state
- [ ] Verify categorical (indeterminate) layer checkboxes continue to function correctly