### PR TITLE
Disable blank issues in GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## Summary

- Added `.github/ISSUE_TEMPLATE/config.yml` to disable blank issue creation, ensuring all new issues use one of the predefined issue templates.

## Focus Score

**10/10** — This merge request makes a single, targeted change to one file for one purpose: disabling blank issues.

## Detailed Summary of Each File Changed

- **`.github/ISSUE_TEMPLATE/config.yml`** (new file): Added a configuration file with `blank_issues_enabled: false` to prevent users from creating issues without using a template.

## Test Plan

- Navigate to the **Issues** tab on GitHub and click "New Issue."
- Verify that users are presented only with the predefined issue templates and cannot open a blank issue.