### PR TITLE
Add feature request contact link to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Feature Request
+    url: https://github.com/raft-tech/GeoSet/discussions
+    about: Suggest a feature or enhancement in GeoSet Discussions


### PR DESCRIPTION
## Summary

- Added a "Feature Request" contact link to the GitHub issue template configuration, pointing users to GeoSet Discussions for feature suggestions.

## Focus Score

**10/10** — Single, targeted change to one file for one purpose: re-enabling the feature request option in the new issue chooser.

## Detailed Summary of Each File Changed

- **`.github/ISSUE_TEMPLATE/config.yml`**: Added a `contact_links` section with a "Feature Request" entry that directs users to https://github.com/raft-tech/GeoSet/discussions to suggest features or enhancements.

## Test Plan

- Navigate to the **Issues** tab on GitHub and click "New Issue."
- Verify that a "Feature Request" option appears alongside the existing templates (Bug Report, Cosmetic Issue, Generic Issue).
- Click the "Feature Request" option and confirm it redirects to the GeoSet Discussions page.