### PR TITLE
chore: version bump workflow creates PR instead of pushing to main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -7,14 +7,13 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
+  # Phase 1: Create version bump PR (runs when a human merges to main)
   bump-version:
     runs-on: ubuntu-latest
     if: github.actor != 'github-actions[bot]'
-    outputs:
-      new_version: ${{ steps.version.outputs.new_version }}
 
     steps:
       - name: Checkout Code
@@ -62,22 +61,50 @@ jobs:
 
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH="chore/version-bump-${{ steps.version.outputs.new_version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add VERSIONING.md
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
-          git push
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: bump version to ${{ steps.version.outputs.new_version }}" \
+            --body "Automated version bump and changelog update." \
+            --base main \
+            --head "$BRANCH"
+
+  # Phase 2: Tag and build Docker (runs when the bot's version bump PR is merged)
+  create-tag:
+    runs-on: ubuntu-latest
+    if: github.actor == 'github-actions[bot]'
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          NEW_VERSION=$(grep -oP '(?<=\*\*Current Version:\*\* )\S+' VERSIONING.md)
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create tag
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "v${{ steps.version.outputs.new_version }}"
           git push origin "v${{ steps.version.outputs.new_version }}"
 
   docker-debian:
     runs-on: ubuntu-latest
-    needs: bump-version
+    needs: create-tag
 
     steps:
       - name: Checkout Code
@@ -104,20 +131,20 @@ jobs:
           target: lean
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ebienstock/geoset:${{ needs.bump-version.outputs.new_version }}
-          build-args: BUILD_VERSION=${{ needs.bump-version.outputs.new_version }}
+          tags: ebienstock/geoset:${{ needs.create-tag.outputs.new_version }}
+          build-args: BUILD_VERSION=${{ needs.create-tag.outputs.new_version }}
           cache-from: type=gha,scope=debian
           cache-to: type=gha,mode=max,scope=debian
 
       - name: Tag as latest
         run: |
           docker buildx imagetools create \
-            ebienstock/geoset:${{ needs.bump-version.outputs.new_version }} \
+            ebienstock/geoset:${{ needs.create-tag.outputs.new_version }} \
             --tag ebienstock/geoset:latest
 
   docker-rhel:
     runs-on: ubuntu-latest
-    needs: bump-version
+    needs: create-tag
 
     steps:
       - name: Checkout Code
@@ -145,20 +172,20 @@ jobs:
           target: production
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ebienstock/geoset:${{ needs.bump-version.outputs.new_version }}-rhel
-          build-args: BUILD_VERSION=${{ needs.bump-version.outputs.new_version }}
+          tags: ebienstock/geoset:${{ needs.create-tag.outputs.new_version }}-rhel
+          build-args: BUILD_VERSION=${{ needs.create-tag.outputs.new_version }}
           cache-from: type=gha,scope=rhel
           cache-to: type=gha,mode=max,scope=rhel
 
       - name: Tag as latest
         run: |
           docker buildx imagetools create \
-            ebienstock/geoset:${{ needs.bump-version.outputs.new_version }}-rhel \
+            ebienstock/geoset:${{ needs.create-tag.outputs.new_version }}-rhel \
             --tag ebienstock/geoset:latest-rhel
 
   docker-ingest:
     runs-on: ubuntu-latest
-    needs: bump-version
+    needs: create-tag
 
     steps:
       - name: Checkout Code
@@ -184,12 +211,12 @@ jobs:
           context: ./sample-data
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ebienstock/geoset:data-ingest-${{ needs.bump-version.outputs.new_version }}
+          tags: ebienstock/geoset:data-ingest-${{ needs.create-tag.outputs.new_version }}
           cache-from: type=gha,scope=data-ingest
           cache-to: type=gha,mode=max,scope=data-ingest
 
       - name: Tag as latest
         run: |
           docker buildx imagetools create \
-            ebienstock/geoset:data-ingest-${{ needs.bump-version.outputs.new_version }} \
+            ebienstock/geoset:data-ingest-${{ needs.create-tag.outputs.new_version }} \
             --tag ebienstock/geoset:data-ingest-latest


### PR DESCRIPTION
## Summary
The version bump workflow previously pushed commits and tags directly to `main`. This required the `github-actions[bot]` account to bypass branch protection rules, which isn't possible without setting up a dedicated GitHub App (which requires org admin permissions we don't have).

This PR changes the workflow to create a pull request for the version bump instead, working within existing branch protection rules.

## Previous workflow
1. Human merges a PR to `main`
2. Workflow bumps the version, commits directly to `main`, creates a git tag, and triggers Docker builds — all automatically

## New workflow
1. **Human merges a PR to `main`** → workflow creates a version bump PR with the updated `VERSIONING.md`
2. **Human merges the version bump PR** → workflow detects `github-actions[bot]` as the actor, creates the git tag, and triggers Docker builds

The only additional manual step is merging the version bump PR.

## Changes
- Replaced the direct commit-and-push step with a step that creates a branch and opens a PR
- Added a `create-tag` job that runs only when `github-actions[bot]` is the actor (i.e., when the version bump PR is merged)
- Docker build jobs now depend on `create-tag` instead of `bump-version`
- Added `pull-requests: write` permission for the workflow to create PRs

## Test plan
- [ ] Merge a PR to main and verify a version bump PR is created automatically
- [ ] Merge the version bump PR and verify the git tag is created and Docker builds run
- [ ] Verify that merging a regular (non-bot) PR does not trigger the tag/Docker phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)