### PR TITLE
fix: version bump workflow not updating changelog

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -54,10 +54,10 @@ jobs:
           else
             PR_LINK=""
           fi
-          sed -i "/^| Version | PR | Description |/,/^$/{
-            /^| ------- | -- |/a\\
-          | $NEW_VERSION | $PR_LINK | $PR_TITLE |
-          }" VERSIONING.md
+          # Insert new changelog row after the table separator line
+          NEW_ROW="| $NEW_VERSION | $PR_LINK | $PR_TITLE |"
+          awk -v row="$NEW_ROW" '/^\| -+ \| -+ \| -+ \|$/ { print; print row; next } 1' VERSIONING.md > VERSIONING.md.tmp
+          mv VERSIONING.md.tmp VERSIONING.md
 
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- The `sed` command in the version bump workflow failed to insert changelog rows because its pattern (`| PR |`) didn't match the actual VERSIONING.md spacing (`| PR  |`)
- Replaced `sed` range/append with `awk`, which uses a flexible regex (`-+`) to match the table separator line regardless of dash count or spacing

## Test plan
- [ ] Merge a PR to `main` and verify the automated version bump PR includes a new row in the VERSIONING.md changelog table

🤖 Generated with [Claude Code](https://claude.com/claude-code)