### PR TITLE
fix: version bump fails when stale branch exists

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -68,6 +68,8 @@ jobs:
           BRANCH="chore/version-bump-${{ steps.version.outputs.new_version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Delete stale remote branch from a previous failed run, if it exists
+          git push origin --delete "$BRANCH" 2>/dev/null || true
           git checkout -b "$BRANCH"
           git add VERSIONING.md
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"


### PR DESCRIPTION
## Summary
- The version bump workflow fails if a previous run left a stale `chore/version-bump-X.Y.Z` branch on the remote (e.g. from a failed run that pushed the branch but didn't create the PR)
- Added `git push origin --delete` before pushing to clean up any leftover branch from a previous attempt

## Test plan
- [ ] Manually re-run the version bump workflow and verify it succeeds even with the existing `chore/version-bump-6.0.33` branch on the remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)