### PR TITLE
fix: version bump Phase 2 (tag + Docker) never runs

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -10,10 +10,10 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Phase 1: Create version bump PR (runs when a human merges to main)
+  # Phase 1: Create version bump PR (runs for non-version-bump commits)
   bump-version:
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]'
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore: bump version to') }}
 
     steps:
       - name: Checkout Code
@@ -80,10 +80,10 @@ jobs:
             --base main \
             --head "$BRANCH"
 
-  # Phase 2: Tag and build Docker (runs when the bot's version bump PR is merged)
+  # Phase 2: Tag and build Docker (runs when a version bump PR is merged)
   create-tag:
     runs-on: ubuntu-latest
-    if: github.actor == 'github-actions[bot]'
+    if: ${{ startsWith(github.event.head_commit.message, 'chore: bump version to') }}
     outputs:
       new_version: ${{ steps.version.outputs.new_version }}
 


### PR DESCRIPTION
## Summary
- Phase 2 (`create-tag` + Docker builds) was skipped because it checked `github.actor == 'github-actions[bot]'`, but the actor is always the human who clicks merge, not the bot that authored the PR
- Replaced actor-based detection with commit message detection: checks if the commit starts with `chore: bump version to` (which is the exact message Phase 1 creates)
- Phase 1 condition updated with the inverse check so it doesn't double-bump when a version bump PR is merged

## Test plan
- [ ] Merge this PR and verify Phase 1 runs (creates a version bump PR)
- [ ] Merge the resulting version bump PR and verify Phase 2 runs (creates tag + triggers Docker builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)