### PR TITLE
fix: skip CI and Docker builds on version bump PRs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   set-tag:
+    if: ${{ !startsWith(github.head_ref, 'chore/version-bump-') }}
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/geoset-backend-ci.yml
+++ b/.github/workflows/geoset-backend-ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   backend-check:
+    if: ${{ !startsWith(github.head_ref, 'chore/version-bump-') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/geoset-frontend-ci.yml
+++ b/.github/workflows/geoset-frontend-ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   frontend-build:
+    if: ${{ !startsWith(github.head_ref, 'chore/version-bump-') }}
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"


### PR DESCRIPTION
## Summary
- Frontend CI, backend CI, and Docker build workflows were running on automated version bump PRs (which only change `VERSIONING.md`), wasting CI minutes
- Added `if: !startsWith(github.head_ref, 'chore/version-bump-')` to skip these workflows on version bump PR branches
- Tagged Docker builds already run in Phase 2 of the version-bump workflow after merge

## Test plan
- [ ] Merge this PR, let the version bump PR be created, and verify frontend CI / backend CI / Docker build do **not** run on it
- [ ] Verify CI still runs normally on regular PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)