### PR TITLE
Fix empty layers spinning forever in Multi Map legend

### DIFF
--- a/superset-frontend/plugins/geoset-map-chart/src/GeoSetMultiMap/Multi.tsx
+++ b/superset-frontend/plugins/geoset-map-chart/src/GeoSetMultiMap/Multi.tsx
@@ -342,10 +342,6 @@ const DeckMulti = (props: DeckMultiProps) => {
                   handleFeatureClick(info, sliceFeatureInfoColumnNames),
               );
 
-              if (!newLayer) {
-                return null;
-              }
-
               const payloadData = payload?.data || [];
               const geometryType = getGeometryType(payloadData[0]?.geojson);
               let transformPropsGeojsonLayer =
@@ -470,13 +466,15 @@ const DeckMulti = (props: DeckMultiProps) => {
                 maxZoom: zoomSlider[1],
               };
 
-              const newLayerStates = layerStatesGenerator(
-                newLayer,
-                newLayerStateOptions,
-              );
+              // When the layer has no renderable data, return an entry with
+              // empty layerStates so the legend can show it as "loaded but
+              // empty" instead of spinning forever.
+              const newLayerStates = newLayer
+                ? layerStatesGenerator(newLayer, newLayerStateOptions)
+                : [];
 
               if (!newLayerStates.length) {
-                return null;
+                legendEntry.empty = true;
               }
 
               const layerFeatures: JsonObject[] =

--- a/superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx
+++ b/superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx
@@ -176,12 +176,13 @@ const Bounds = styled.div(
 `,
 );
 
-const VisibilityCheckbox = styled.input`
+const VisibilityCheckbox = styled.input<{ $empty?: boolean }>`
   width: 14px;
   height: 14px;
   cursor: pointer;
   margin: 0 !important;
   flex-shrink: 0;
+  ${({ $empty }) => $empty && 'accent-color: gray;'}
 `;
 
 // Checkbox that supports indeterminate state (shows minus sign when some but not all are selected)
@@ -189,7 +190,8 @@ const IndeterminateCheckbox: React.FC<{
   checked: boolean;
   indeterminate: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-}> = ({ checked, indeterminate, onChange }) => {
+  $empty?: boolean;
+}> = ({ checked, indeterminate, onChange, $empty }) => {
   const ref = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -204,6 +206,7 @@ const IndeterminateCheckbox: React.FC<{
       type="checkbox"
       checked={checked}
       onChange={onChange}
+      $empty={$empty}
     />
   );
 };
@@ -246,6 +249,7 @@ const LegendEntryContent: React.FC<{
                 type="checkbox"
                 checked={isVisible}
                 onChange={onToggleVisibility}
+                $empty={legendEntry.empty}
               />
             )}
             <Swatch
@@ -299,6 +303,7 @@ const LegendEntryContent: React.FC<{
                         type="checkbox"
                         checked={item.enabled}
                         onChange={() => onToggleCategory(sliceId, item.label)}
+                        $empty={legendEntry.empty}
                       />
                     )}
                     <span>{item.label}</span>
@@ -324,6 +329,7 @@ const LegendEntryContent: React.FC<{
                         type="checkbox"
                         checked={isEnabled}
                         onChange={() => onToggleCategory(sliceId, cat.label)}
+                        $empty={legendEntry.empty}
                       />
                     )}
                     <Swatch
@@ -364,6 +370,7 @@ const LegendEntryContent: React.FC<{
                 type="checkbox"
                 checked={isVisible}
                 onChange={onToggleVisibility}
+                $empty={legendEntry.empty}
               />
               <Swatch
                 fill={fill}
@@ -493,6 +500,9 @@ export const MultiLegend: React.FC<MultiLegendProps> = ({
               someVisibleSomeNot || (isVisible && hasPartialCategories);
 
             const allLoading = entries.every(e => e.legendEntry.loading);
+            const allEmpty = !allLoading && entries.every(
+              e => e.legendEntry.empty,
+            );
 
             return (
               <Group key={displayTitle}>
@@ -505,6 +515,7 @@ export const MultiLegend: React.FC<MultiLegendProps> = ({
                       <IndeterminateCheckbox
                         checked={isVisible}
                         indeterminate={isIndeterminate}
+                        $empty={allEmpty}
                         onChange={e => {
                           e.stopPropagation();
                           setOptimisticVisibility(prev => ({

--- a/superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx
+++ b/superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx
@@ -151,6 +151,13 @@ const CategoryRow = styled.div`
   gap: 8px;
 `;
 
+const NoDataLabel = styled.div`
+  font-size: 11px;
+  color: gray;
+  margin-bottom: 6px;
+  margin-left: -20px;
+`;
+
 const MetricBlock = styled.div`
   margin: 6px 0;
 `;
@@ -239,6 +246,9 @@ const LegendEntryContent: React.FC<{
 
   return (
     <div>
+      {legendEntry.empty && (
+        <NoDataLabel>Visible but Empty</NoDataLabel>
+      )}
       {/* SIMPLE - show icon and slice name (skip when sizeEntry handles the display) */}
       {legendEntry.type === 'simple' &&
         legendEntry.simpleStyle &&

--- a/superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx
+++ b/superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx
@@ -500,9 +500,8 @@ export const MultiLegend: React.FC<MultiLegendProps> = ({
               someVisibleSomeNot || (isVisible && hasPartialCategories);
 
             const allLoading = entries.every(e => e.legendEntry.loading);
-            const allEmpty = !allLoading && entries.every(
-              e => e.legendEntry.empty,
-            );
+            const allEmpty =
+              !allLoading && entries.every(e => e.legendEntry.empty);
 
             return (
               <Group key={displayTitle}>

--- a/superset-frontend/plugins/geoset-map-chart/src/types.ts
+++ b/superset-frontend/plugins/geoset-map-chart/src/types.ts
@@ -104,6 +104,7 @@ export type LegendEntry = {
   isCombinedMetricSize?: boolean;
   initialCollapsed?: boolean; // Whether this legend entry starts collapsed
   loading?: boolean; // True for stub entries whose layer data is still loading
+  empty?: boolean; // True when layer loaded successfully but returned no data
 };
 
 export type LegendGroup = {

--- a/superset-frontend/plugins/geoset-map-chart/test/components/MultiLegend.test.tsx
+++ b/superset-frontend/plugins/geoset-map-chart/test/components/MultiLegend.test.tsx
@@ -564,4 +564,215 @@ describe('MultiLegend', () => {
       expect(screen.getByText('500+')).toBeInTheDocument();
     });
   });
+
+  describe('empty layer state', () => {
+    it('shows checkbox and "no data" label instead of spinner for empty entry', () => {
+      renderWithTheme(
+        <MultiLegend
+          legendGroups={[
+            createLegendGroup({
+              displayTitle: 'Empty Group',
+              entries: [
+                {
+                  sliceId: '1',
+                  legendEntry: createSimpleLegendEntry({
+                    legendName: 'Empty Layer',
+                    empty: true,
+                  }),
+                },
+              ],
+            }),
+            createLegendGroup({ displayTitle: 'Other' }),
+          ]}
+          layerVisibility={EMPTY_VISIBILITY}
+          onToggleLayerVisibility={jest.fn()}
+        />,
+      );
+      userEvent.click(screen.getByText('Legend'));
+      expect(screen.getByText('Empty Layer')).toBeInTheDocument();
+      expect(
+        screen.getByText('Visible but Empty'),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('does not show "no data" label for non-empty entry', () => {
+      renderWithTheme(
+        <MultiLegend
+          legendGroups={[
+            createLegendGroup({
+              entries: [
+                {
+                  sliceId: '1',
+                  legendEntry: createSimpleLegendEntry({
+                    legendName: 'Normal Layer',
+                  }),
+                },
+              ],
+            }),
+          ]}
+          layerVisibility={EMPTY_VISIBILITY}
+        />,
+      );
+      userEvent.click(screen.getByText('Legend'));
+      expect(screen.getByText('Normal Layer')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Visible but Empty'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('group header shows checkbox (not spinner) when all entries are empty', () => {
+      renderWithTheme(
+        <MultiLegend
+          legendGroups={[
+            createLegendGroup({
+              displayTitle: 'All Empty',
+              entries: [
+                {
+                  sliceId: '1',
+                  legendEntry: createSimpleLegendEntry({ empty: true }),
+                },
+                {
+                  sliceId: '2',
+                  legendEntry: createSimpleLegendEntry({ empty: true }),
+                },
+              ],
+            }),
+            createLegendGroup({ displayTitle: 'Other' }),
+          ]}
+          layerVisibility={EMPTY_VISIBILITY}
+          onToggleLayerVisibility={jest.fn()}
+        />,
+      );
+      userEvent.click(screen.getByText('Legend'));
+      // Group header should render a checkbox, not a loading spinner
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes.length).toBeGreaterThanOrEqual(2);
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('group header checkbox is present when some entries have data', () => {
+      renderWithTheme(
+        <MultiLegend
+          legendGroups={[
+            createLegendGroup({
+              displayTitle: 'Mixed',
+              entries: [
+                {
+                  sliceId: '1',
+                  legendEntry: createSimpleLegendEntry({ empty: true }),
+                },
+                {
+                  sliceId: '2',
+                  legendEntry: createSimpleLegendEntry({ empty: false }),
+                },
+              ],
+            }),
+            createLegendGroup({ displayTitle: 'Other' }),
+          ]}
+          layerVisibility={EMPTY_VISIBILITY}
+          onToggleLayerVisibility={jest.fn()}
+        />,
+      );
+      userEvent.click(screen.getByText('Legend'));
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('shows spinner when loading, even if empty is also true', () => {
+      renderWithTheme(
+        <MultiLegend
+          legendGroups={[
+            createLegendGroup({
+              displayTitle: 'Loading',
+              entries: [
+                {
+                  sliceId: '1',
+                  legendEntry: createSimpleLegendEntry({
+                    loading: true,
+                    empty: true,
+                  }),
+                },
+              ],
+            }),
+            createLegendGroup({
+              displayTitle: 'Other',
+              entries: [
+                {
+                  sliceId: '2',
+                  legendEntry: createSimpleLegendEntry({
+                    loading: true,
+                  }),
+                },
+              ],
+            }),
+          ]}
+          layerVisibility={EMPTY_VISIBILITY}
+          onToggleLayerVisibility={jest.fn()}
+        />,
+      );
+      userEvent.click(screen.getByText('Legend'));
+      // Both group headers should show spinners, not checkboxes
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Visible but Empty'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('transitions from loading to empty without spinner', () => {
+      const { rerender } = renderWithTheme(
+        <MultiLegend
+          legendGroups={[
+            createLegendGroup({
+              displayTitle: 'Transitioning',
+              entries: [
+                {
+                  sliceId: '1',
+                  legendEntry: createSimpleLegendEntry({
+                    legendName: 'Trans Layer',
+                    loading: true,
+                  }),
+                },
+              ],
+            }),
+            createLegendGroup({ displayTitle: 'Other' }),
+          ]}
+          layerVisibility={EMPTY_VISIBILITY}
+          onToggleLayerVisibility={jest.fn()}
+        />,
+      );
+      userEvent.click(screen.getByText('Legend'));
+      expect(
+        screen.queryByText('Visible but Empty'),
+      ).not.toBeInTheDocument();
+
+      // Re-render with loading finished and empty result
+      rerender(
+        <MultiLegend
+          legendGroups={[
+            createLegendGroup({
+              displayTitle: 'Transitioning',
+              entries: [
+                {
+                  sliceId: '1',
+                  legendEntry: createSimpleLegendEntry({
+                    legendName: 'Trans Layer',
+                    loading: false,
+                    empty: true,
+                  }),
+                },
+              ],
+            }),
+            createLegendGroup({ displayTitle: 'Other' }),
+          ]}
+          layerVisibility={EMPTY_VISIBILITY}
+          onToggleLayerVisibility={jest.fn()}
+        />,
+      );
+      expect(screen.getByText('Trans Layer')).toBeInTheDocument();
+      expect(
+        screen.getByText('Visible but Empty'),
+      ).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Differentiate between **loading** and **empty** layer states in the Multi Map legend so that layers with no data stop showing an infinite spinner
- Add a gray "Visible but Empty" label below the group title for empty layers, aligned with the group header
- Gray out the checkbox accent color for empty layer entries
- Add 6 tests covering the new empty layer behavior

Closes #350

## Focus Score

**9/10** — All changes are tightly scoped to one bug: empty layers causing an infinite spinner in the Multi Map legend. The only files touched are the legend component, its test file, the layer processing logic in Multi.tsx, and the shared type definition. The formatting commit is a minor tangent but affects the same file.

## Detailed Summary of Each File Changed

### `superset-frontend/plugins/geoset-map-chart/src/GeoSetMultiMap/Multi.tsx`
- Removed the early `return null` when `getGeoSetMapLayer` returns null (empty data)
- Changed `layerStatesGenerator` call to a ternary that returns `[]` when `newLayer` is falsy
- Changed the `!newLayerStates.length` branch from `return null` to setting `legendEntry.empty = true`, so the entry still reaches the legend

### `superset-frontend/plugins/geoset-map-chart/src/components/MultiLegend.tsx`
- Added `NoDataLabel` styled component (gray, 11px, aligned with group title via `margin-left: -20px`)
- Renders "Visible but Empty" text when `legendEntry.empty` is true
- Added `$empty` transient prop to `VisibilityCheckbox` and `IndeterminateCheckbox` to apply `accent-color: gray` styling
- Computed `allEmpty` at the group level for the group header checkbox

### `superset-frontend/plugins/geoset-map-chart/src/types.ts`
- Added `empty?: boolean` field to the `LegendEntry` type

### `superset-frontend/plugins/geoset-map-chart/test/components/MultiLegend.test.tsx`
- Added 6 tests in a new `empty layer state` describe block:
  1. Empty entry shows checkbox + "Visible but Empty" label (not spinner)
  2. Non-empty entry does not show the label
  3. Group header shows checkbox when all entries are empty
  4. Group header checkbox present when mix of empty/non-empty
  5. Loading takes precedence over empty (spinners shown)
  6. Transition from loading to empty replaces spinner with label

## Test Plan

- [ ] **Automated**: Run `npx jest --config jest.config.js plugins/geoset-map-chart/test/components/MultiLegend.test.tsx` — all 30 tests should pass
- [ ] **Manual**: Open the Hurricane dashboard with year filter set to 2026 (no data). Verify the legend shows "Visible but Empty" in gray text instead of an infinite spinner
- [ ] **Manual**: Switch the year filter to a year with data (e.g. 2024). Verify the spinner transitions to the normal legend content
- [ ] **Manual**: With multiple layer groups, verify the group-level checkbox turns gray when all entries in the group are empty